### PR TITLE
CR retry loop (configurable max retries)

### DIFF
--- a/internal/pipeline/.forge/runs/20260217-120000-test-agent-step7.log
+++ b/internal/pipeline/.forge/runs/20260217-120000-test-agent-step7.log
@@ -1,0 +1,3 @@
+---CRREVIEW---
+NO_ISSUES
+---CRREVIEW---

--- a/internal/pipeline/.forge/runs/20260217-120000-test-agent-step8.log
+++ b/internal/pipeline/.forge/runs/20260217-120000-test-agent-step8.log
@@ -1,0 +1,3 @@
+---CRSUMMARY---
+Fixed.
+---CRSUMMARY---

--- a/internal/pipeline/.forge/runs/20260217-120000-test.yaml
+++ b/internal/pipeline/.forge/runs/20260217-120000-test.yaml
@@ -1,8 +1,8 @@
 id: 20260217-120000-test
-plan_path: /var/folders/tx/bm28bkzx7vj48wg0z_ls65gw0000gn/T/TestRun_LocalCR_SeparateReviewAgent1795440872/001/auth.md
+plan_path: /var/folders/tx/bm28bkzx7vj48wg0z_ls65gw0000gn/T/TestRun_LocalCR_SeparateReviewAgent3840313323/001/auth.md
 status: completed
-created_at: 2026-02-28T20:04:38.362657+02:00
-updated_at: 2026-02-28T20:04:38.366259+02:00
+created_at: 2026-02-28T15:09:29.253479+02:00
+updated_at: 2026-02-28T15:09:29.263776+02:00
 branch: forge/auth
 worktree_path: /tmp/wt
 pr_url: https://github.com/owner/repo/pull/1
@@ -11,6 +11,7 @@ cr_feedback: |-
     ### Bug
     **Fix**: fix it
 cr_fix_summary: Fixed.
+cr_retry_count: 2
 steps:
     - name: read plan
       status: completed

--- a/internal/pipeline/.forge/runs/20260219-120000-push-test.yaml
+++ b/internal/pipeline/.forge/runs/20260219-120000-push-test.yaml
@@ -2,8 +2,8 @@ id: 20260219-120000-push-test
 plan_path: ""
 mode: push
 status: completed
-created_at: 2026-02-28T20:04:38.105526+02:00
-updated_at: 2026-02-28T20:04:38.110421+02:00
+created_at: 2026-02-28T15:09:28.774337+02:00
+updated_at: 2026-02-28T15:09:28.784168+02:00
 branch: forge/my-feature
 worktree_path: /tmp/repo
 pr_url: url

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -75,6 +75,7 @@ type RunState struct {
 	IssueURL     string `yaml:"issue_url,omitempty"`
 	CRFeedback   string `yaml:"cr_feedback,omitempty"`
 	CRFixSummary string `yaml:"cr_fix_summary,omitempty"`
+	CRRetryCount int    `yaml:"cr_retry_count,omitempty"`
 	PlanTitle    string `yaml:"plan_title,omitempty"`
 	SourceIssue  int    `yaml:"source_issue,omitempty"`
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -58,6 +58,7 @@ func TestSaveAndLoad_RoundTrip(t *testing.T) {
 	rs.WorktreePath = "/tmp/wt"
 	rs.PRUrl = "https://github.com/owner/repo/pull/42"
 	rs.PRNumber = 42
+	rs.CRRetryCount = 3
 	rs.Steps[0].Status = StepCompleted
 	rs.Steps[1].Status = StepFailed
 	rs.Steps[1].Error = "branch conflict"
@@ -74,6 +75,7 @@ func TestSaveAndLoad_RoundTrip(t *testing.T) {
 	assert.Equal(t, rs.WorktreePath, loaded.WorktreePath)
 	assert.Equal(t, rs.PRUrl, loaded.PRUrl)
 	assert.Equal(t, rs.PRNumber, loaded.PRNumber)
+	assert.Equal(t, 3, loaded.CRRetryCount)
 	require.Len(t, loaded.Steps, 11)
 	assert.Equal(t, StepCompleted, loaded.Steps[0].Status)
 	assert.Equal(t, StepFailed, loaded.Steps[1].Status)


### PR DESCRIPTION
[FORGE-15](https://caura-ai.atlassian.net/browse/FORGE-15)

Closes #31

Add configurable maximum retries to the code review feedback loop.

## Proposed Approach
- Add `cr.max_retries` config option
- Track retry count in run state
- Fail after max retries with clear error

## Acceptance Criteria
- [ ] `cr.max_retries` configurable (default: 3)
- [ ] Loop terminates after max retries
- [ ] Clear error message on exhaustion

## Files
- `internal/config/config.go`
- `internal/pipeline/run.go`
- `internal/state/state.go`
