### PR TITLE
feat: add per-step timestamps to StepState

### DIFF
--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -404,17 +404,20 @@ func runStep(rs *state.RunState, idx int, logger *slog.Logger, fn func() error) 
 
 	step.Status = state.StepRunning
 	step.Error = ""
+	step.StartedAt = time.Now()
 	_ = rs.Save()
 
 	if err := fn(); err != nil {
 		step.Status = state.StepFailed
 		step.Error = err.Error()
+		step.CompletedAt = time.Now()
 		rs.Status = state.RunFailed
 		_ = rs.Save()
 		return fmt.Errorf("step %d (%s): %w", idx+1, step.Name, err)
 	}
 
 	step.Status = state.StepCompleted
+	step.CompletedAt = time.Now()
 	_ = rs.Save()
 	return nil
 }

--- a/internal/pipeline/run_test.go
+++ b/internal/pipeline/run_test.go
@@ -497,6 +497,45 @@ func TestRun_StateTrackingHappyPath(t *testing.T) {
 	}
 }
 
+func TestRun_StepTimestampsPopulated(t *testing.T) {
+	wt := &mockWorktree{createPath: "/tmp/wt"}
+	ag := &mockAgent{}
+	vc := &mockVCS{pr: &provider.PR{URL: "https://github.com/owner/repo/pull/42", Number: 42}}
+
+	planPath := writePlan(t, "implement auth")
+	rs := newRunState(planPath)
+	before := time.Now()
+
+	err := Run(context.Background(), testConfig(), defaultProviders(wt, ag, vc), planPath, rs, testLogger())
+
+	require.NoError(t, err)
+	after := time.Now()
+	for _, step := range rs.Steps {
+		assert.False(t, step.StartedAt.IsZero(), "step %q should have StartedAt set", step.Name)
+		assert.False(t, step.CompletedAt.IsZero(), "step %q should have CompletedAt set", step.Name)
+		assert.True(t, !step.StartedAt.Before(before), "step %q StartedAt should be after test start", step.Name)
+		assert.True(t, !step.CompletedAt.After(after), "step %q CompletedAt should be before test end", step.Name)
+		assert.True(t, !step.CompletedAt.Before(step.StartedAt), "step %q CompletedAt should be >= StartedAt", step.Name)
+	}
+}
+
+func TestRun_FailedStepHasTimestamps(t *testing.T) {
+	wt := &mockWorktree{createPath: "/tmp/wt"}
+	ag := &mockAgent{err: errors.New("agent failed")}
+	vc := &mockVCS{}
+
+	planPath := writePlan(t, "will fail")
+	rs := newRunState(planPath)
+
+	_ = Run(context.Background(), testConfig(), defaultProviders(wt, ag, vc), planPath, rs, testLogger())
+
+	// Step 4 (run agent) should have failed with timestamps set.
+	step := rs.Steps[4]
+	assert.Equal(t, state.StepFailed, step.Status)
+	assert.False(t, step.StartedAt.IsZero(), "failed step should have StartedAt")
+	assert.False(t, step.CompletedAt.IsZero(), "failed step should have CompletedAt")
+}
+
 func TestRun_ResumeSkipsCompletedSteps(t *testing.T) {
 	wt := &mockWorktree{createPath: "/tmp/wt"}
 	ag := &mockAgent{}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -52,9 +52,11 @@ var StepNames = []string{
 
 // StepState tracks status and error for a single pipeline step.
 type StepState struct {
-	Name   string     `yaml:"name"`
-	Status StepStatus `yaml:"status"`
-	Error  string     `yaml:"error,omitempty"`
+	Name        string     `yaml:"name"`
+	Status      StepStatus `yaml:"status"`
+	Error       string     `yaml:"error,omitempty"`
+	StartedAt   time.Time  `yaml:"started_at,omitempty"`
+	CompletedAt time.Time  `yaml:"completed_at,omitempty"`
 }
 
 // RunState is the persistent state for a single pipeline run.

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -82,6 +82,54 @@ func TestSaveAndLoad_RoundTrip(t *testing.T) {
 	assert.Equal(t, "branch conflict", loaded.Steps[1].Error)
 }
 
+func TestSaveAndLoad_StepTimestamps(t *testing.T) {
+	cleanup := setupTestDir(t)
+	defer cleanup()
+
+	rs := New("20260312-timestamps", "plans/ts.md")
+	now := time.Now().Truncate(time.Second)
+	rs.Steps[0].Status = StepCompleted
+	rs.Steps[0].StartedAt = now.Add(-10 * time.Second)
+	rs.Steps[0].CompletedAt = now
+
+	require.NoError(t, rs.Save())
+
+	loaded, err := Load(rs.ID)
+	require.NoError(t, err)
+
+	assert.WithinDuration(t, rs.Steps[0].StartedAt, loaded.Steps[0].StartedAt, time.Second)
+	assert.WithinDuration(t, rs.Steps[0].CompletedAt, loaded.Steps[0].CompletedAt, time.Second)
+	// Pending steps should have zero timestamps.
+	assert.True(t, loaded.Steps[1].StartedAt.IsZero())
+	assert.True(t, loaded.Steps[1].CompletedAt.IsZero())
+}
+
+func TestBackwardsCompat_OldStateWithoutTimestamps(t *testing.T) {
+	cleanup := setupTestDir(t)
+	defer cleanup()
+
+	// Simulate an old state file without timestamp fields.
+	require.NoError(t, os.MkdirAll(runsDir, 0o755))
+	oldYAML := `id: old-run
+plan_path: plans/old.md
+status: completed
+created_at: 2026-01-01T00:00:00Z
+updated_at: 2026-01-01T00:00:00Z
+steps:
+  - name: read plan
+    status: completed
+  - name: create issue
+    status: pending
+`
+	require.NoError(t, os.WriteFile(filepath.Join(runsDir, "old-run.yaml"), []byte(oldYAML), 0o644))
+
+	loaded, err := Load("old-run")
+	require.NoError(t, err)
+	assert.Equal(t, StepCompleted, loaded.Steps[0].Status)
+	assert.True(t, loaded.Steps[0].StartedAt.IsZero(), "old files without timestamps should load with zero time")
+	assert.True(t, loaded.Steps[0].CompletedAt.IsZero())
+}
+
 func TestLoad_Nonexistent(t *testing.T) {
 	cleanup := setupTestDir(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary
Closes #60

- Add `StartedAt` and `CompletedAt` timestamp fields to `StepState` with `yaml:"...,omitempty"` tags
- Set timestamps in `runStep()` when status transitions to `running` and `completed`/`failed`
- Old state YAML files without these fields load without error (zero value)

## Test plan
- [x] `TestSaveAndLoad_StepTimestamps` — round-trip serialization
- [x] `TestBackwardsCompat_OldStateWithoutTimestamps` — old files load cleanly
- [x] `TestRun_StepTimestampsPopulated` — happy path sets all timestamps
- [x] `TestRun_FailedStepHasTimestamps` — failed steps also get both timestamps
- [x] `make test` passes (all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)